### PR TITLE
Fix build-image workflow trigger

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -7,6 +7,14 @@ on:
     tags:
       - 'v*'
   pull_request:
+    paths:
+      - '.github/workflows/build-image.yml'
+      - 'docker-bake.hcl'
+      - 'Dockerfile*'
+      - 'rust-toolchain'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'src/**'
 
 jobs:
   build_image:


### PR DESCRIPTION
- 流石に時間かかりすぎるのでnot requiredにした
- なら`paths`すべきでしょ